### PR TITLE
Merge changes to magnetometer data parsing function

### DIFF
--- a/helmholtzcage/Magnetometer.py
+++ b/helmholtzcage/Magnetometer.py
@@ -137,6 +137,7 @@ class Magnetometer:
         print(f"Config Info: {config_info}, Sign/Decimal Info: {sign_decimal_info}, Number: {actual_number}")
         '''
 
+        print("byte array", data_point)
         # FIXME : Test this code, then remove this comment when working
         config_info = data_point[0]                             # config info we don't use yet
         sign_decimal_info = data_point[1]                       # second byte tells sign and decimal place

--- a/helmholtzcage/Magnetometer.py
+++ b/helmholtzcage/Magnetometer.py
@@ -145,7 +145,7 @@ class Magnetometer:
 
         raw_value = struct.unpack(">I", data_point[2:6])[0] & 0xFFFFFFFF # 32 bits for unsigned integer value of the data point
         value = (sign * raw_value) / (10.0 ** decimal_power)    # converts to signed float32
-        print("Config info: {:b}\nSign/Decimal: {:b}\nuInt Value: {}\nValue: {}".format(config_info, sign_decimal_info, raw_value, value))
+        print("Config info: {:b} Sign/Decimal: {:b} uInt Value: {} Value: {}".format(config_info, sign_decimal_info, raw_value, value))
         return {'config' : config_info, 'sign' : sign, 'power' : decimal_power, 'raw_value' : raw_value, 'value' : value} 
         
                 


### PR DESCRIPTION
I used the Alpha lab docs to perform bit-wise operations which convert the data point from an unsigned integer to a signed floating point value.

The modified `parse_data_point()` function in `Magnetometer.py` now returns a dictionary with the parsed input after printing the data point components.

The signed magnetometer value can be read by accessing the 'value' variable in the returned dict. ie `data['value']`