### PR TITLE
Field control

### DIFF
--- a/helmholtzcage/HelmholtzShell.py
+++ b/helmholtzcage/HelmholtzShell.py
@@ -381,8 +381,14 @@ class HelmholtzShell(cmd.Cmd):
 
     def do_set_field(self, arg):
         # testing
+        args = arg.split(" ")
+        vals = []
+        for val in args:
+            try:
+                vals.append(int(val))
+            except: ValueError
         if not self.mock:
-            self.utility.set_field_vector(arg) 
+            self.utility.set_field_vector(vals) 
 
     def help_set_field(self):
         # testing!

--- a/helmholtzcage/HelmholtzShell.py
+++ b/helmholtzcage/HelmholtzShell.py
@@ -378,7 +378,17 @@ class HelmholtzShell(cmd.Cmd):
     def do_average(self, arg):
         if not self.mock:
             self.utility.reading_avg()
-            
+
+    def do_set_field(self, arg):
+        # testing
+        if not self.mock:
+            self.utility.set_field_vector(*arg) 
+
+    def help_set_field(self):
+        # testing!
+        print("This command sets and outputs a magnetic field vector")
+        print("Arguments are integers separated by spaces")
+        print("Eg. 10 20 30 attempts to form X:10 Y:20 Z:30")
         
     #Closes program and exits. 
     def do_exit(self, arg):

--- a/helmholtzcage/HelmholtzShell.py
+++ b/helmholtzcage/HelmholtzShell.py
@@ -382,7 +382,7 @@ class HelmholtzShell(cmd.Cmd):
     def do_set_field(self, arg):
         # testing
         if not self.mock:
-            self.utility.set_field_vector(*arg) 
+            self.utility.set_field_vector(arg) 
 
     def help_set_field(self):
         # testing!

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -6,17 +6,20 @@ import matplotlib.pyplot as plt
 from scipy import stats
 import numpy as np
 from .Magnetometer import Magnetometer, MagnetometerCommands
+from .Arduino import Arduino, ArduinoCommands
+from .ZXY6005s import ZXY6005s, ZXY6005sCommands
 
 class Utilities:
     #Class utilities constructor.
-    def __init__(self, meter: Magnetometer):
+    def __init__(self, meter: Magnetometer, arduino: Arduino, psu: ZXY6005s):
         super().__init__()
         self.meter = meter
+        self.arduino = arduino
+        self.psu = psu
         pass
     
     ##Prototype function to calculate the milligauss averages of all 3 axis using the STREAM function. (WIP)
-    def reading_avg(self):
-        
+    def reading_avg(self): 
         #Variables needed. 
         sum_x = 0
         sum_y = 0
@@ -34,34 +37,28 @@ class Utilities:
                 print("sum_y:", sum_y)
                 sum_z += chunk[3]['value']
                 print("sum_z:", sum_z)
-                #count += 1
+                count += 1
             else:
                 print("Warning: bad data encountered.")
         
         #Now find the averages of all 3 axes.
-        x_avg = sum_x/num_iterations 
-        y_avg = sum_y/num_iterations
-        z_avg = sum_z/num_iterations
-
+        x_avg = sum_x/count
+        y_avg = sum_y/count
+        z_avg = sum_z/count
 
         print("x avg:", x_avg)
         print("y avg:", y_avg)
-        print("z avg:", z_avg)           
+        print("z avg:", z_avg) 
         
-        #Negated. 
-        negated_x = 0 - x_avg 
-        negated_y = 0 - y_avg
-        negated_z = 0 - z_avg
-        negate = []
-        negate.append(x_avg, y_avg, z_avg)
-        return negate
+        mag_readings = np.array([x_avg, y_avg, z_avg])
+        return mag_readings
         
     
+    ''' Deprecating
     #Prototype function for getting the currents needed to match to earth's magnetic field. 
     def magnetic_to_current_zero(self):
-        
         #This function to zero out the field in the cage utilizes the negated averages of each cage axis. 
-        
+
         #First, get the y-value (y = desired_mag_field - mag_averages)
         data = self.reading_avg() #Call the reading average function and store the data.
         adjusted_field_x = 0 - data[0]
@@ -75,6 +72,7 @@ class Utilities:
 
         ambient_mag = np.array([adjusted_feild_x, adjusted_field_y, adjusted_field_z])
         return ambient_mag
+    '''
         
     def to_output_current(self, *raw_currents):
        # Maps theoretical current value to an output current to adjust for power supply errors
@@ -84,15 +82,45 @@ class Utilities:
        out_curr_vec = (out_curr_vec + 28.3) // 1.23
        return out_curr_vec
 
-    def to_output_mag(self, raw_mag, ambient_mag):
-       # Adjusts  magnetic field vector for output errors
+    def mag_to_current(self, raw_mag, ambient_mag):
+       # Adjusts magnetic field vector to remove ambient influences and system error
        if len(raw_mag) < 3:
            print("Error: Magnetic field vector must have length 3, got {}".format(len(raw_mag)))
            return np.array([0, 0, 0])
        else:
-           xyz_slope = np.array([-1.27, 1.27, -1.1])
+           xyz_slope = np.array([-1.27, 1.27, -1.1])    # hard-coded slope for linearly approximated output curve
+           ambient_mag = np.array(ambient_mag)          # recorded ambient temperature
            raw_mag = np.array(raw_mag)
-           ambient_mag = np.array(ambient_mag)
            out_mag = (raw_mag - ambient_mag) // xyz_slope
            return out_mag
+    
+    def set_field_vector(self, *target):
+        # Attempts to set magnetic field in cage to the specified vector, assuming zero if argument is left empty
+        target = np.array(target)
+        out_field = np.array([0, 0, 0])
+        out_field += target[:2]           # sets output vector to xyz targets from arguments
+        print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
+        # calculating current settings
+        ambient_field = self.reading_avg()
+        target_current = self.mag_to_current(out_field, ambient_field)
+        out_current = self.to_output_current(*target_current)
+        
+        if (out_current.min() < -800 or out_current.max() > 800):
+            print("output currents are out of range!!\ncancelling output")
+            return -1
+
+        # updating H-Bridges
+        self.arduino.set_positive_X if out_curr[0] > 0 else self.arduino.set_negative_X
+        self.arduino.set_positive_Y if out_curr[1] > 0 else self.arduino.set_negative_Y
+        self.arduino.set_positive_Z if out_curr[2] > 0 else self.arduino.set_negative_Z
+
+        # updating PSUs
+        for i, dev in enumerate(['X', 'Y', 'Z']):
+            self.psu.set_current_limit(dev, out_current[i])
+
+        # powering up PSUs
+        for dev in ['X', 'Y', 'Z']:
+            self.psu.set_output(dev, 1)
+
+        return 0

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -32,11 +32,11 @@ class Utilities:
             chunk = self.meter.stream_data() 
             if (chunk != []):
                 sum_x += chunk[1]['value']
-                print("sum_x:",sum_x)                
+                # print("sum_x:",sum_x)                
                 sum_y += chunk[2]['value']
-                print("sum_y:", sum_y)
+                # print("sum_y:", sum_y)
                 sum_z += chunk[3]['value']
-                print("sum_z:", sum_z)
+                # print("sum_z:", sum_z)
                 count += 1
             else:
                 print("Warning: bad data encountered.")
@@ -96,10 +96,9 @@ class Utilities:
     
     def set_field_vector(self, target):
         # Attempts to set magnetic field in cage to the specified vector, assuming zero if argument is left empty
-        print(target)
         target = np.array(target)
         out_field = np.array([0, 0, 0])
-        outfield = out_field + target          # sets output vector to xyz targets from arguments
+        outfield = target          # sets output vector to xyz targets from arguments
         print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
         # calculating current settings

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -1,5 +1,5 @@
 #Utils.py library
-#Author(s): Gustavo A. Cotom
+#Author(s): Gustavo A. Cotom, Emily Snodgrass, Daniel Monahan
 #This file contains the utility functions needed to calibrate the PSAS Helmholtz Cage. 
 
 import matplotlib.pyplot as plt

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -118,10 +118,10 @@ class Utilities:
 
         # updating PSUs
         for i, dev in enumerate(['X', 'Y', 'Z']):
-            self.psu.set_current_limit(dev, out_current[i])
+            self.psu.set_current_limit(dev, float(out_current[i]))
 
         # powering up PSUs
         for dev in ['X', 'Y', 'Z']:
-            self.psu.set_output(dev, 1)
+            self.psu.set_output(dev, float(1))
 
         return 0

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -112,9 +112,9 @@ class Utilities:
             return -1
 
         # updating H-Bridges
-        self.arduino.set_positive_X if out_current[0] > 0 else self.arduino.set_negative_X
-        self.arduino.set_positive_Y if out_current[1] > 0 else self.arduino.set_negative_Y
-        self.arduino.set_positive_Z if out_current[2] > 0 else self.arduino.set_negative_Z
+        self.arduino.set_positive_X() if out_current[0] > 0 else self.arduino.set_negative_X()
+        self.arduino.set_positive_Y() if out_current[1] > 0 else self.arduino.set_negative_Y()
+        self.arduino.set_positive_Z() if out_current[2] > 0 else self.arduino.set_negative_Z()
 
         # updating PSUs
         for i, dev in enumerate(['X', 'Y', 'Z']):

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -118,7 +118,7 @@ class Utilities:
 
         # updating PSUs
         for i, dev in enumerate(['X', 'Y', 'Z']):
-            self.psu.set_current_limit(dev, int(out_current[i]))
+            self.psu.set_current_limit(dev, int(abs(out_current[i]))i)
 
         # powering up PSUs
         for dev in ['X', 'Y', 'Z']:

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -118,7 +118,7 @@ class Utilities:
 
         # updating PSUs
         for i, dev in enumerate(['X', 'Y', 'Z']):
-            self.psu.set_current_limit(dev, int(abs(out_current[i]))i)
+            self.psu.set_current_limit(dev, int(abs(out_current[i])))
 
         # powering up PSUs
         for dev in ['X', 'Y', 'Z']:

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -99,7 +99,6 @@ class Utilities:
     def set_field_vector(self, target):
         # Attempts to set magnetic field in cage to the specified vector, assuming zero if argument is left empty
         out_field = np.array(target)          # xyz targets from arguments
-        print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
         # calculating current settings
         ambient_field = self.reading_avg()
@@ -109,6 +108,7 @@ class Utilities:
         if (out_current.min() < -800 or out_current.max() > 800):
             print("output currents are out of range!!\ncancelling output")
             return -1
+        print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
         # updating H-Bridges
         self.arduino.set_positive_X() if out_current[0] > 0 else self.arduino.set_negative_X()

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -96,9 +96,7 @@ class Utilities:
     
     def set_field_vector(self, target):
         # Attempts to set magnetic field in cage to the specified vector, assuming zero if argument is left empty
-        target = np.array(target)
-        out_field = np.array([0, 0, 0])
-        outfield = target          # sets output vector to xyz targets from arguments
+        out_field = np.array(target)          # xyz targets from arguments
         print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
         # calculating current settings

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -118,10 +118,10 @@ class Utilities:
 
         # updating PSUs
         for i, dev in enumerate(['X', 'Y', 'Z']):
-            self.psu.set_current_limit(dev, float(out_current[i]))
+            self.psu.set_current_limit(dev, int(out_current[i]))
 
         # powering up PSUs
         for dev in ['X', 'Y', 'Z']:
-            self.psu.set_output(dev, float(1))
+            self.psu.set_output(dev, int(1))
 
         return 0

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -79,7 +79,7 @@ class Utilities:
        slope = 1.23
        y_int = 28.3
        out_curr_vec = np.array(raw_currents)
-       out_curr_vec = (out_curr_vec + 28.3) // 1.23
+       out_curr_vec = (out_curr_vec - y_int) // slope
        return out_curr_vec
 
     def mag_to_current(self, raw_mag, ambient_mag):
@@ -94,11 +94,12 @@ class Utilities:
            out_mag = (raw_mag - ambient_mag) // xyz_slope
            return out_mag
     
-    def set_field_vector(self, *target):
+    def set_field_vector(self, target):
         # Attempts to set magnetic field in cage to the specified vector, assuming zero if argument is left empty
+        print(target)
         target = np.array(target)
         out_field = np.array([0, 0, 0])
-        out_field += target[:2]           # sets output vector to xyz targets from arguments
+        outfield = out_field + target[:2]          # sets output vector to xyz targets from arguments
         print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
         # calculating current settings

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -112,9 +112,9 @@ class Utilities:
             return -1
 
         # updating H-Bridges
-        self.arduino.set_positive_X if out_curr[0] > 0 else self.arduino.set_negative_X
-        self.arduino.set_positive_Y if out_curr[1] > 0 else self.arduino.set_negative_Y
-        self.arduino.set_positive_Z if out_curr[2] > 0 else self.arduino.set_negative_Z
+        self.arduino.set_positive_X if out_current[0] > 0 else self.arduino.set_negative_X
+        self.arduino.set_positive_Y if out_current[1] > 0 else self.arduino.set_negative_Y
+        self.arduino.set_positive_Z if out_current[2] > 0 else self.arduino.set_negative_Z
 
         # updating PSUs
         for i, dev in enumerate(['X', 'Y', 'Z']):

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -99,7 +99,7 @@ class Utilities:
         print(target)
         target = np.array(target)
         out_field = np.array([0, 0, 0])
-        outfield = out_field + target[:2]          # sets output vector to xyz targets from arguments
+        outfield = out_field + target          # sets output vector to xyz targets from arguments
         print("Setting magnetic field to target vector : {}, {}, {}".format(*out_field))
 
         # calculating current settings

--- a/helmholtzcage/utils.py
+++ b/helmholtzcage/utils.py
@@ -74,24 +74,26 @@ class Utilities:
         return ambient_mag
     '''
         
-    def to_output_current(self, *raw_currents):
+    def to_output_current(self, target_currents):
        # Maps theoretical current value to an output current to adjust for power supply errors
-       slope = 1.23
-       y_int = 28.3
-       out_curr_vec = np.array(raw_currents)
+       if len(target_currents) < 3:
+           print("Error: Target current provided to 'to_output_current()' must be size (3). Got ({})".format(len(target_currents)))
+       slope = np.array([1.22, 1.23, 1.25])
+       y_int = np.array([26.4, 33.6, 25])
+       out_curr_vec = np.array(target_currents)
        out_curr_vec = (out_curr_vec - y_int) // slope
        return out_curr_vec
 
-    def mag_to_current(self, raw_mag, ambient_mag):
+    def mag_to_current(self, target_mag, ambient_mag):
        # Adjusts magnetic field vector to remove ambient influences and system error
-       if len(raw_mag) < 3:
-           print("Error: Magnetic field vector must have length 3, got {}".format(len(raw_mag)))
+       if len(target_mag) < 3:
+           print("Error: Magnetic field vector must have length 3, got {}".format(len(target_mag)))
            return np.array([0, 0, 0])
        else:
            xyz_slope = np.array([-1.27, 1.27, -1.1])    # hard-coded slope for linearly approximated output curve
            ambient_mag = np.array(ambient_mag)          # recorded ambient temperature
-           raw_mag = np.array(raw_mag)
-           out_mag = (raw_mag - ambient_mag) // xyz_slope
+           target_mag = np.array(target_mag)
+           out_mag = (target_mag - ambient_mag) // xyz_slope
            return out_mag
     
     def set_field_vector(self, target):
@@ -102,7 +104,7 @@ class Utilities:
         # calculating current settings
         ambient_field = self.reading_avg()
         target_current = self.mag_to_current(out_field, ambient_field)
-        out_current = self.to_output_current(*target_current)
+        out_current = self.to_output_current(target_current)
         
         if (out_current.min() < -800 or out_current.max() > 800):
             print("output currents are out of range!!\ncancelling output")

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ else:
     arduino = Arduino(args.arduino_location)
     psu = ZXY6005s()
     meter = Magnetometer.Magnetometer(args.meter_location)
-    utility = utils.Utilities(meter)
+    utility = utils.Utilities(meter=meter, arduino=arduino, psu=psu)
 
 shell = HelmholtzShell(arduino, psu, meter, utility, args.mock)
 for i in 'xyz':

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ smbus2==0.4.3
 pyserial==3.5 
 PyQt5==5.15.10
 pyqtgraph==0.13.7 
+scipy==1.14.1


### PR DESCRIPTION
This merge would include functions such as `set_field` to be used in the dev branch, allowing the user to approximate a given field vector using experimentally collected calibration data.
usage example,
```
> set_field 10 10 10
Setting magnetic field to target vector : 10, 10, 10
```

Other new additions are conversion functions in the `utils.py` file which convert a target field vector into a target current vector (`mag_to_current()`) and convert a target current vector to an output current vector (`to_output_current()`).